### PR TITLE
I've added Dockerfiles for development and updated docker-compose.

### DIFF
--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,0 +1,21 @@
+# Use an official Python runtime as a parent image
+FROM python:3.11-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container at /app
+COPY requirements.txt ./
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application code
+COPY . .
+
+# Make port 8000 available to the world outside this container
+EXPOSE 8000
+
+# Run uvicorn server when the container launches
+# Adjust the main:app part if your FastAPI application instance is named differently or located in a different file
+CMD ["uvicorn", "contact_api:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,12 +24,11 @@ version: '3.8'
 
 services:
   frontend:
-    # build:
-    #   context: ./frontend
-    #   dockerfile: Dockerfile.dev  # Placeholder: Dockerfile needs to be created in ./frontend
-    image: node:18-alpine  # Using a pre-built Node.js image for placeholder
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.dev
     container_name: contact_form_frontend_dev
-    command: sh -c "echo 'Frontend container running (placeholder). In a real setup, this would run your dev server (e.g., npm start).' && tail -f /dev/null"
+    command: npm run dev
     ports:
       - "3000:3000"  # Standard port for React/Vue/Angular dev servers
     volumes:
@@ -46,12 +45,11 @@ services:
     restart: unless-stopped
 
   backend:
-    # build:
-    #   context: ./backend
-    #   dockerfile: Dockerfile.dev  # Placeholder: Dockerfile needs to be created in ./backend
-    image: python:3.11-slim  # Using a pre-built Python image for placeholder
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.dev
     container_name: contact_form_backend_dev
-    command: sh -c "echo 'Backend container running (placeholder). In a real setup, this would run your FastAPI/uvicorn server.' && tail -f /dev/null"
+    command: uvicorn contact_api:app --host 0.0.0.0 --port 8000 --reload
     ports:
       - "8000:8000"  # Standard port for Python web frameworks like FastAPI/Flask
     volumes:

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,21 @@
+# Use an official Node.js runtime as a parent image
+FROM node:18-alpine
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy package.json and package-lock.json (if available)
+COPY package.json ./
+COPY package-lock.json* ./
+
+# Install project dependencies
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Make port 3000 available to the world outside this container
+EXPOSE 3000
+
+# Run the app when the container launches
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
I created Dockerfile.dev for both frontend and backend services to enable local development builds.

- Frontend Dockerfile.dev:
  - Uses node:18-alpine as base.
  - Installs npm dependencies from package.json.
  - Exposes port 3000 and runs `npm run dev`.

- Backend Dockerfile.dev:
  - Uses python:3.11-slim as base.
  - Installs pip dependencies from requirements.txt.
  - Exposes port 8000 and runs uvicorn with reload for `contact_api:app`.

I also updated docker-compose.yml:
- I configured frontend and backend services to use their respective Dockerfile.dev for building.
- I updated service commands to start development servers.
- I removed pre-built image references for these services.

These changes allow you to build and run the frontend and backend services locally using docker-compose for a consistent development environment.